### PR TITLE
Wrong value in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ new Vue({
 |`location`|change the location of the progress bar|`top`|`left`, `right`, `top`, `bottom`|
 |`position`|change the position of the progress bar|`fixed`|`relative`, `absolute`, `fixed`|
 |`inverse`|inverse the direction of the progress bar|`false`|`true`, `false`|
-|`autoFinish`|allow the progress bar to finish automatically when it is close to 100%|`false`|`true`, `true`|
+|`autoFinish`|allow the progress bar to finish automatically when it is close to 100%|`false`|`true`, `false`|
 
 ## Implementation
 


### PR DESCRIPTION
Both provided options were 'true'