### PR TITLE
fix default positioning on server

### DIFF
--- a/src/vue-progressbar.vue
+++ b/src/vue-progressbar.vue
@@ -55,6 +55,7 @@ export default {
                     options: {
                         canSuccess: true,
                         show: false,
+                        position: 'static',
                         color: 'rgb(19, 91, 55)',
                         failedColor: 'red',
                         thickness: '2px',


### PR DESCRIPTION
Prevent progress bar from taking up space when rendered on the server.

In the long run it would be good to make it possible to merge the default options also with the options for the server case.